### PR TITLE
DELIA-60700: OCDM process usage investigation

### DIFF
--- a/src/rdk_perf_clock.cpp
+++ b/src/rdk_perf_clock.cpp
@@ -86,8 +86,8 @@ void PerfClock::SetWallClock()
 void PerfClock::SetCPU()
 {
     struct rusage data;
-    // int who = RUSAGE_SELF; 
-    int who = RUSAGE_THREAD; 
+    int who = RUSAGE_SELF; 
+    //int who = RUSAGE_THREAD; 
     if(getrusage(who, &data) == -1) {
          LOG(eError, "getrusage failure %d: %s\n", errno, strerror(errno));
     }
@@ -141,10 +141,10 @@ void PerfClock::Now(PerfClock* pClock, Operation operation)
         pClock->SetWallClock(elapsed.GetWallClock() - pClock->GetWallClock());
         pClock->SetUserCPU(elapsed.GetUserCPU() - pClock->GetUserCPU());
         pClock->SetSystemCPU(elapsed.GetSystemCPU() - pClock->GetSystemCPU());
-        LOG(eWarning, "Got Time Elapsed (computed) %0.3lf User %0.3lf System %0.3lf\n", 
+        LOG(eTrace, "Got Time Elapsed (computed) %0.3lf User %lu System %lu\n", 
             (double)pClock->GetWallClock() / 1000.0,
-            (double)pClock->GetUserCPU() / 1000.0,
-            (double)pClock->GetSystemCPU() / 1000.0);
+            pClock->GetUserCPU(),
+            pClock->GetSystemCPU());
     }
     else {
         LOG(eError, "Unknown operation mode\n");

--- a/src/rdk_perf_node.h
+++ b/src/rdk_perf_node.h
@@ -50,6 +50,8 @@ typedef struct _TimingStats
     uint64_t            nLastDelta;
     uint64_t            nUserCPU;
     uint64_t            nSystemCPU;
+    uint64_t            nIntervalUserCPU;
+    uint64_t            nIntervalSystemCPU;
     uint64_t            nTotalUserCPU;
     uint64_t            nTotalSystemCPU;
 } TimingStats;
@@ -78,7 +80,7 @@ public:
     void IncrementData(uint64_t deltaTime, uint64_t userCPU, uint64_t systemCPU);
     void ResetInterval();
 
-    void ReportData(uint32_t nLevel, bool bShowOnlyDelta = false);
+    void ReportData(uint32_t nLevel, bool bShowOnlyDelta, uint32_t msIntervalTime);
 
 private:
     pthread_t               m_idThread;

--- a/src/rdk_perf_process.h
+++ b/src/rdk_perf_process.h
@@ -30,6 +30,7 @@
 #include <list>
 #include <map>
 #include <stack>
+#include "rdk_perf_clock.h"
 
 #define PROCESS_NAMELEN 80
 
@@ -55,6 +56,7 @@ private:
     pid_t                           m_idProcess;
     char                            m_ProcessName[PROCESS_NAMELEN];
     std::map<pthread_t, PerfTree*>  m_mapThreads;
+    PerfClock                       m_clock;
 };
 
 PerfProcess* RDKPerf_FindProcess(pid_t pID);

--- a/src/rdk_perf_record.cpp
+++ b/src/rdk_perf_record.cpp
@@ -100,7 +100,7 @@ PerfRecord::~PerfRecord()
                         ((double)deltaTime) / 1000.0,
                         ((double)stats->nTotalTime / (double)stats->nTotalCount) / 1000.0,
                         ((double)stats->nIntervalTime / (double)stats->nIntervalCount) / 1000.0);
-        m_nodeInTree->ReportData(0, true);
+        m_nodeInTree->ReportData(0, true, 0);
     }
 
     return;

--- a/src/rdk_perf_record.h
+++ b/src/rdk_perf_record.h
@@ -54,7 +54,7 @@ public:
     void            SetThreshold(int32_t nUS)       { m_ThresholdInUS = (int32_t)nUS; };
     void            SetNodeInTree(PerfNode* pNode)  { m_nodeInTree = pNode; };
  
-    void            ReportData(uint32_t nLevel, bool bShowOnlyDelta = false);
+    void            ReportData(uint32_t nLevel, bool bShowOnlyDelta, uint32_t msIntervalTime = 0);
 
 private:
     pthread_t               m_idThread;

--- a/src/rdk_perf_tree.cpp
+++ b/src/rdk_perf_tree.cpp
@@ -135,11 +135,12 @@ void PerfTree::CloseActiveNode(PerfNode* pTreeNode)
     return;
 }
 
-void PerfTree::ReportData()
+void PerfTree::ReportData(uint32_t msIntervalTime)
 {
     // Get the root node and walk down the tree
-    LOG(eWarning, "Printing report on %X thread named %s\n", (uint32_t)m_idThread, m_ThreadName);
-    m_rootNode->ReportData(0);
+    LOG(eWarning, "Printing report on %X thread named %s, Interval Elapsed wallClock: %lu ms\n",
+        (uint32_t)m_idThread, m_ThreadName, msIntervalTime);
+    m_rootNode->ReportData(0, false, msIntervalTime);
     
     // Update the activity monitor
     m_CountAtLastReport = m_ActivityCount;

--- a/src/rdk_perf_tree.h
+++ b/src/rdk_perf_tree.h
@@ -47,7 +47,7 @@ public:
     PerfNode* AddNode(PerfRecord* pRecord);
     PerfNode* AddNode(char* szName, pthread_t tID, char* szThreadName, uint64_t nStartTime);
     void CloseActiveNode(PerfNode* pTreeNode);
-    void ReportData();
+    void ReportData(uint32_t msIntervalTime=0);
 
     bool IsInactive();
     char * GetName() { return m_ThreadName; };


### PR DESCRIPTION
Reason for change: uses the CPU usage time allocation when PERF_SHOW_CPU is enabled.

Test Procedure: If PERF_SHOW_CPU is disabled, logs look the same. When PERF_SHOW_CPU is enabled, it will show the % and time usage of CPU for each node.

Risks: Low
Priority: P2
Signed-off-by: Mario Luzeiro <mario.luzeiro@sky.uk>